### PR TITLE
ERA-70: Supplier Management: Mutual Aid Bug

### DIFF
--- a/responders/src/UI/embc-responder/src/app/core/api/models/mutual-aid.ts
+++ b/responders/src/UI/embc-responder/src/app/core/api/models/mutual-aid.ts
@@ -3,6 +3,7 @@
 import { SupplierTeam } from '../models/supplier-team';
 export interface MutualAid {
   givenByTeamId?: string | null;
+  givenByTeamName?: string | null;
   givenOn?: string;
   givenToTeam?: SupplierTeam;
 }

--- a/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/suppliers-table/suppliers-table.component.html
+++ b/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/suppliers-table/suppliers-table.component.html
@@ -36,7 +36,7 @@
           }
           @if (column?.ref === 'mutualAid') {
             <span>
-              <span>{{ row[column?.ref]?.givenToTeam?.name }}</span>
+              <span>{{ row[column?.ref]?.givenByTeamName }}</span>
             </span>
           }
           @if (column?.ref === 'status') {

--- a/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/suppliers-table/suppliers-table.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/suppliers-table/suppliers-table.component.ts
@@ -127,8 +127,8 @@ export class SuppliersTableComponent implements AfterViewInit, OnChanges {
             return compare(a.name.toLowerCase(), b.name.toLowerCase(), isAsc);
           case 'mutualAid':
             return compare(
-              a.mutualAid?.givenToTeam?.name.toLowerCase(),
-              b.mutualAid?.givenToTeam?.name.toLowerCase(),
+              a.mutualAid?.givenByTeamName?.toLowerCase(),
+              b.mutualAid?.givenByTeamName?.toLowerCase(),
               isAsc
             );
           case 'status':


### PR DESCRIPTION
- Extract all team IDs that provided mutual aid from supplier records
- Team name lookup by querying suppliers for each team ID and extracting team information
- Added GivenByTeamName property to MutualAid class

_For Sunshine User (Test Team 3) show the Team Name providing the MutualAid:_
<img width="1038" height="375" alt="image" src="https://github.com/user-attachments/assets/41e514df-abf7-460c-88fd-59bc63c5f40b" />

[ERA-70](https://emcr.atlassian.net/browse/ERA-70)