### PR TITLE
Fix issue when GST number is null

### DIFF
--- a/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/supplier-detail/supplier-detail.component.html
+++ b/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/supplier-detail/supplier-detail.component.html
@@ -27,8 +27,15 @@
       <div class="row row-align">
         <div class="col-md-4 detail-label">GST Number</div>
         <div class="col-md-8">
-          {{ selectedSupplier?.supplierGstNumber?.part1 }} -RT-
-          {{ selectedSupplier?.supplierGstNumber?.part2 }}
+          <ng-container
+            *ngIf="
+              selectedSupplier?.supplierGstNumber?.part1 && selectedSupplier?.supplierGstNumber?.part2;
+              else emptyGST
+            "
+          >
+            {{ selectedSupplier?.supplierGstNumber?.part1 }} -RT- {{ selectedSupplier?.supplierGstNumber?.part2 }}
+          </ng-container>
+          <ng-template #emptyGST></ng-template>
         </div>
       </div>
 

--- a/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/supplier-detail/supplier-detail.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/supplier-detail/supplier-detail.component.ts
@@ -44,7 +44,7 @@ import { MatAutocompleteTrigger, MatAutocomplete } from '@angular/material/autoc
 import { MatInput } from '@angular/material/input';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { MatButton } from '@angular/material/button';
-import { AsyncPipe, UpperCasePipe, DatePipe } from '@angular/common';
+import { AsyncPipe, UpperCasePipe, DatePipe, CommonModule } from '@angular/common';
 import { MatCard, MatCardContent } from '@angular/material/card';
 
 @Component({
@@ -53,6 +53,7 @@ import { MatCard, MatCardContent } from '@angular/material/card';
   styleUrls: ['./supplier-detail.component.scss'],
   standalone: true,
   imports: [
+    CommonModule,
     MatCard,
     MatCardContent,
     MatButton,

--- a/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/supplier-management.service.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/supplier-management.service.ts
@@ -11,10 +11,13 @@ export class SupplierManagementService {
   constructor(private locationServices: LocationsService) {}
 
   convertSupplierGSTNumberToFormModel(gstNumber: string): GstNumberModel {
+    if (!gstNumber) {
+      return { part1: '', part2: '' };
+    }
     const gstArray: string[] = gstNumber.split('-RT-', 2);
     const convertedGstNumber: GstNumberModel = {
-      part1: gstArray[0],
-      part2: gstArray[1]
+      part1: gstArray[0] || '',
+      part2: gstArray[1] || ''
     };
 
     return convertedGstNumber;

--- a/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/supplier-list-data.service.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/supplier-list-data.service.ts
@@ -131,8 +131,10 @@ export class SupplierListDataService {
           resolve();
         },
         error: (error) => {
+          console.error('Error in getSupplierById:', error);
           this.alertService.clearAlert();
           this.alertService.setAlert('danger', globalConst.getSupportByIdError);
+          reject(error);
         }
       });
     });

--- a/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/suppliers-list.component.ts
+++ b/responders/src/UI/embc-responder/src/app/feature-components/supplier-management/suppliers-list/suppliers-list.component.ts
@@ -95,12 +95,18 @@ export class SuppliersListComponent implements OnInit {
     this.isLoading = true;
     this.supplierListDataService.getSupplierDetails($event.id, 'supplier').then(() => {
       this.isLoading = false;
+    })
+    .catch(() => {
+      this.isLoading = false;
     });
   }
 
   openMutualAidDetails($event: SupplierListItem): void {
     this.isLoading = true;
     this.supplierListDataService.getSupplierDetails($event.id, 'mutualAid').then(() => {
+      this.isLoading = false;
+    })
+    .catch(() => {
       this.isLoading = false;
     });
   }


### PR DESCRIPTION
**Cause:**
This issue is due to null values in the GST number in Dynamics. In the portal, we enforce that the user provides a value, but Dynamics might lack this validation.:
<img width="777" height="590" alt="image" src="https://github.com/user-attachments/assets/8238038d-26c0-4340-ae8c-a565a230fb2f" />

**Fix:**
- The `convertSupplierGSTNumberToFormModel` method now safely handles cases where the input GST number is null, undefined, or empty by returning an object with empty string parts, preventing runtime errors.
- Added detailed logging for error cases.